### PR TITLE
[WSF-116] Complete Task Endpoint

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -3,7 +3,7 @@ import { ColumnType, Generated } from 'kysely'
 
 interface AppUserTable {
   eth_address: string
-  reward_points: number
+  reward_points: Generated<ColumnType<number, number, never>>
   created_at: Generated<ColumnType<Date, never, never>>
 }
 
@@ -35,3 +35,5 @@ export interface Database {
  * DO NOT IMPORT IN CLIENT FACING CODE!
  */
 export const db = createKysely<Database>()
+
+export const POSTGRES_KEY_ALREADY_EXISTS_ERROR_CODE = '23505'

--- a/src/pages/api/user/complete-task.ts
+++ b/src/pages/api/user/complete-task.ts
@@ -1,0 +1,90 @@
+import { splitSignature, verifyMessage } from 'ethers/lib/utils'
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { db, POSTGRES_KEY_ALREADY_EXISTS_ERROR_CODE } from '../../../database'
+
+type RequestData = {
+  data: {
+    eth_address: string
+    task_id: number
+    task_group_name: string
+  }
+  signature: string
+}
+
+type ResponseData = {
+  message: string
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ResponseData>
+) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({
+      message: 'Bad HTTP method.',
+    })
+  }
+
+  const { data, signature }: RequestData = req.body
+
+  const signatureObject = splitSignature(signature)
+
+  const verification =
+    verifyMessage(JSON.stringify(data), signatureObject) === data.eth_address
+
+  if (verification !== true) {
+    return res.status(403).json({
+      message: "Message signature doesn't match.",
+    })
+  }
+
+  // Check if user is already in DB
+  const user = await db
+    .selectFrom('app_user')
+    .select('eth_address')
+    .where('eth_address', '=', data.eth_address)
+    .executeTakeFirst()
+
+  // If not, save the user
+  if (user == null) {
+    try {
+      await db
+        .insertInto('app_user')
+        .columns(['eth_address'])
+        .values({
+          eth_address: data.eth_address,
+        })
+        .execute()
+    } catch (error) {
+      return res.status(500).json({
+        message: 'Error saving user.',
+      })
+    }
+  }
+
+  try {
+    await db
+      .insertInto('completed_task')
+      .columns(['task_group_name', 'task_id', 'completed_by'])
+      .values({
+        task_group_name: data.task_group_name,
+        task_id: data.task_id,
+        completed_by: data.eth_address,
+      })
+      .execute()
+  } catch (error) {
+    if ((error as any).code === POSTGRES_KEY_ALREADY_EXISTS_ERROR_CODE) {
+      return res.status(400).json({
+        message: 'Task already completed.',
+      })
+    }
+
+    return res.status(500).json({
+      message: 'Error saving user.',
+    })
+  }
+
+  return res.json({
+    message: 'success',
+  })
+}


### PR DESCRIPTION
There's a big dummy button on the account page that allows you to complete a task once. Refreshing the page should show tokens credited to your account 🚀 

Example JSON data to send to `POST http://localhost:3000/api/user/complete-task` :
```
{
    "data": {
        "eth_address": "0x4Db633d25Cf5E49D579363fD8Cbb27d7b4a8e8d2",
        "task_id": 1,
        "task_group_name": "sitewide"
    },
    "signature": "0x49f3a46ee60e11f51c67a555581bff74031345dbeb90498148b4861032267caa52c9b9611e402af7de7a85874040b804bf44a72a9debb61ac8f17b26c0ce72321b"
}
```
