### PR TITLE
Update hubspot newsletter api calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@emotion/server": "^11.10.0",
     "@emotion/styled": "^11.10.6",
     "@everipedia/wagmi-magic-connector": "^1.0.2",
-    "@hubspot/api-client": "^8.9.0",
+    "@hubspot/api-client": "^10.1.0",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.11.11",
     "@rainbow-me/rainbowkit": "^1.0.0",

--- a/src/components/landing/Newsletter.tsx
+++ b/src/components/landing/Newsletter.tsx
@@ -30,6 +30,9 @@ const Newsletter = () => {
       body: JSON.stringify({
         email: inputValue,
       }),
+      headers: {
+        'Content-Type': 'application/json',
+      },
     })
     enqueueSnackbar(
       translate(

--- a/src/pages/api/newsletter.ts
+++ b/src/pages/api/newsletter.ts
@@ -1,36 +1,95 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { Client } from '@hubspot/api-client'
-import { SimplePublicObjectInput } from '@hubspot/api-client/lib/codegen/crm/contacts'
+import { getErrorCode } from '@/utils/api'
 
-export type ResponseData = {
+const HUBSPOT_NEWSLETTER_TYPE = 'Wolf Society'
+
+export type NewsletterSubscriptionRequestData = {
+  email: string
+}
+
+export type NewsletterSubscriptionResponseData = {
   message: string
+}
+
+const hubspotClient = new Client({
+  accessToken: process.env.HUBSPOT_ACCESS_TOKEN,
+})
+
+const getErrorMessage = (errorCode: number) => {
+  switch (errorCode) {
+    case 409:
+      return 'E-mail already registered!'
+    default:
+      return 'Unexpected error occured!'
+  }
+}
+
+const findContactByEmail = async (email: string) => {
+  try {
+    return await hubspotClient.crm.contacts.basicApi.getById(
+      email,
+      ['newsletter_subscription_type'],
+      undefined,
+      undefined,
+      false,
+      'email'
+    )
+  } catch {}
 }
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<ResponseData>
+  res: NextApiResponse<NewsletterSubscriptionResponseData>
 ) {
-  if (req.method !== 'POST')
+  if (req.method !== 'POST') {
     res.status(405).json({ message: 'Invalid request method!' })
+    return
+  }
+
   try {
-    const hubspotClient = new Client({
-      accessToken: process.env.HUBSPOT_ACCESS_TOKEN,
-    })
-    const body = JSON.parse(req.body)
-    const contactObj: SimplePublicObjectInput = {
-      properties: {
-        email: body.email,
-      },
+    const { email } = req.body as NewsletterSubscriptionRequestData
+
+    const existingContact = await findContactByEmail(email)
+
+    const existingSubscriptions =
+      existingContact?.properties.newsletter_subscription_type?.split(';') ?? []
+
+    const isAlreadySubscribed = existingSubscriptions.includes(
+      HUBSPOT_NEWSLETTER_TYPE
+    )
+
+    if (isAlreadySubscribed) {
+      res.status(409).json({
+        message: 'E-mail is already subscribed to the newsletter!',
+      })
+      return
     }
-    await hubspotClient.crm.contacts.basicApi.create(contactObj)
+
+    if (existingContact) {
+      const updatedSubscriptions = [
+        ...existingSubscriptions,
+        HUBSPOT_NEWSLETTER_TYPE,
+      ].join(';')
+
+      await hubspotClient.crm.contacts.basicApi.update(existingContact.id, {
+        properties: {
+          newsletter_subscription_type: updatedSubscriptions,
+        },
+      })
+    } else {
+      await hubspotClient.crm.contacts.basicApi.create({
+        properties: {
+          email,
+          newsletter_subscription_type: HUBSPOT_NEWSLETTER_TYPE,
+        },
+        associations: [],
+      })
+    }
+
     res.json({ message: 'E-mail successfully subscribed to the newsletter!' })
-  } catch (err: any) {
-    let errorMessage = 'Unexpected error occured!'
-    switch (err.code) {
-      case 409:
-        errorMessage = 'E-mail already registered!'
-        break
-    }
-    res.status(err.code).json({ message: errorMessage })
+  } catch (error) {
+    const errorCode = getErrorCode(error)
+    res.status(errorCode).json({ message: getErrorMessage(errorCode) })
   }
 }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,0 +1,4 @@
+export const getErrorCode = (error: unknown) =>
+  error instanceof Error && 'code' in error && typeof error.code === 'number'
+    ? error.code
+    : 500

--- a/yarn.lock
+++ b/yarn.lock
@@ -807,10 +807,10 @@
     magic-sdk "^17.1.3"
     tsc-esm-fix "^2.20.10"
 
-"@hubspot/api-client@^8.9.0":
-  version "8.9.0"
-  resolved "https://registry.yarnpkg.com/@hubspot/api-client/-/api-client-8.9.0.tgz#ef5c708f5e217996bcbd0b10b0347762b4c31bb2"
-  integrity sha512-0BrtxZ2hnVtUxnCyDbYVBpoRXC031moUhVyXfyI2YVa0ETtDBSmFPx2p50gj4dXpTP6vwT1IDdA8jur+iiPXsg==
+"@hubspot/api-client@^10.1.0":
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/@hubspot/api-client/-/api-client-10.1.0.tgz#2afbd88dae3b61260e660f5401c0058ec0bbaa9a"
+  integrity sha512-2UMv3xWED0g/l6UM183LxlrFB3CD7oC7bctEvU96+V2KKDoCyFdVWHjjX8Zko7gREODiMnqidyOZt/2akKj75Q==
   dependencies:
     "@types/node-fetch" "^2.5.7"
     bottleneck "^2.19.5"


### PR DESCRIPTION
Since we're adding GOOD marketplace newsletter to the same HubSpot account, we need to differentiate, which emails are registered for which newsletter.

In HubSpot I added "Newsletter subscription type" as a new contact property and this PR updates the HubSpot API calls accordingly. 